### PR TITLE
Don't include a "#" symbol in front of non-numerical tags

### DIFF
--- a/app/views/assets/show.html.erb
+++ b/app/views/assets/show.html.erb
@@ -1,6 +1,6 @@
-<h1>Asset #<%= @asset.tag %></h1>
-<% content_for :info do %>
+<h1>Asset <%= @asset.tag =~ "^[\d]+$" ? "#" + @asset.tag : @asset.tag %></h1>
 
+<% content_for :info do %>
 	<table class="table-condensed" width="100%" >
 		<tr style="font-weight: bolder; color: #666;">
 			<td>Building</td>


### PR DESCRIPTION
Check against a basic digitstring regex and append a "#" symbol in front of @asset.tag when we're referring to numerical tags, but not tags such as "Google Apps" or similar. Only fixes the @asset.tag thing, nothing major.
