### PR TITLE
Remove some extraneous characters from buildings#show

### DIFF
--- a/app/views/buildings/show.html.erb
+++ b/app/views/buildings/show.html.erb
@@ -39,7 +39,7 @@
 </p>
 
 <p>
-	<b>Default Consumable Storeroom:</b> <% if @building.storeroom %>%><%= link_to @building.storeroom.name, @building.storeroom %><% end %>
+	<b>Default Consumable Storeroom:</b> <% if @building.storeroom %><%= link_to @building.storeroom.name, @building.storeroom %><% end %>
 </p>
 
 
@@ -60,11 +60,9 @@
 
 <% content_for :sidebar do %>
 	<% if current_user.admin? %>
-		
+
 		<li><%= link_to "New Room", new_room_path(:building_id => @building.id) %>
 			<li><%= link_to "Edit Building", edit_building_path(@building) %></li><% end %>
 			<li><%= link_to "Add Shortcut", quick_shortcuts_path(:container_type => 'Building', :container_id => @building.id) %></li>
 
 <% end %>
-
-


### PR DESCRIPTION
Removed double trailing whitespace fix plus duplicate closing ERB-tag thing. It appears @Sammidysam included the extra `%>` that was formerly on line 42 by accident. It didn't break anything, but it looked a bit weird.
